### PR TITLE
fixes exluded directories

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -30146,10 +30146,7 @@ async function main() {
     const directoriesInput = core.getInput('excluded_directories');
     const labelColor = core.getInput('label_color') || 'fcffff';
 
-    const excludeSpecs = (specsInput === 'true' || specsInput === 1);
-    const excludedDirectories = directoriesInput || [];
-
-    const size = await sizePR(excludeSpecs, excludedDirectories, labelColor, context, octokit);
+    const size = await sizePR(specsInput, directoriesInput, labelColor, context, octokit);
 
     return core.notice(size);
   } catch (error) {

--- a/index.js
+++ b/index.js
@@ -13,10 +13,7 @@ async function main() {
     const directoriesInput = core.getInput('excluded_directories');
     const labelColor = core.getInput('label_color') || 'fcffff';
 
-    const excludeSpecs = (specsInput === 'true' || specsInput === 1);
-    const excludedDirectories = directoriesInput || [];
-
-    const size = await sizePR(excludeSpecs, excludedDirectories, labelColor, context, octokit);
+    const size = await sizePR(specsInput, directoriesInput, labelColor, context, octokit);
 
     return core.notice(size);
   } catch (error) {

--- a/spec/size-pr.spec.js
+++ b/spec/size-pr.spec.js
@@ -27,11 +27,11 @@ describe("Size PR", function() {
 
   it('adds a label to the PR that indicates the size', async function() {
     let excludeSpecs = false;
-    let excludedDirectories = [];
+    let directoriesInput;
 
     spyOn(octokit.rest.issues, 'addLabels').and.callThrough();
 
-    await sizePR(excludeSpecs, excludedDirectories, color, context, octokit);
+    await sizePR(excludeSpecs, directoriesInput, color, context, octokit);
     expect(octokit.rest.issues.addLabels).toHaveBeenCalledWith({
       ...context.repo,
       issue_number: prNumber,
@@ -41,11 +41,11 @@ describe("Size PR", function() {
 
   it('adds a label to the PR that indicates size when specs are excluded', async function() {
     let excludeSpecs = true;
-    let excludedDirectories = [];
+    let directoriesInput;
 
     spyOn(octokit.rest.issues, 'addLabels').and.callThrough();
 
-    await sizePR(excludeSpecs, excludedDirectories, color, context, octokit);
+    await sizePR(excludeSpecs, directoriesInput, color, context, octokit);
     expect(octokit.rest.issues.addLabels).toHaveBeenCalledWith({
       ...context.repo,
       issue_number: prNumber,
@@ -55,11 +55,11 @@ describe("Size PR", function() {
 
   it('adds a label to the PR that indicates size when directories are excluded', async function() {
     let excludeSpecs = false;
-    let excludedDirectories = ['test'];
+    let directoriesInput = 'test';
 
     spyOn(octokit.rest.issues, 'addLabels').and.callThrough();
 
-    await sizePR(excludeSpecs, excludedDirectories, color, context, octokit);
+    await sizePR(excludeSpecs, directoriesInput, color, context, octokit);
     expect(octokit.rest.issues.addLabels).toHaveBeenCalledWith({
       ...context.repo,
       issue_number: prNumber,
@@ -69,25 +69,42 @@ describe("Size PR", function() {
 
   it('adds a label to the PR that indicates size when both specs and directories are excluded', async function() {
     let excludeSpecs = true;
-    let excludedDirectories = ['test', 'specs'];
+    let directoriesInput = 'src/woot,wow';
 
     spyOn(octokit.rest.issues, 'addLabels').and.callThrough();
 
-    await sizePR(excludeSpecs, excludedDirectories, color, context, octokit);
+    await sizePR(excludeSpecs, directoriesInput, color, context, octokit);
     expect(octokit.rest.issues.addLabels).toHaveBeenCalledWith({
       ...context.repo,
       issue_number: prNumber,
-      labels: ['PR Size: XS']
+      labels: ['PR Size: L']
+    });
+  });
+
+  // Note: this spec ensures there aren't too many files subtracted
+  it('adds a label to the PR that indicates size when both specs and directories match and are excluded', async function() {
+    let excludeSpecs = true;
+    let directoriesInput = 'test,specs';
+
+    spyOn(octokit.rest.issues, 'addLabels').and.callThrough();
+
+    await sizePR(excludeSpecs, directoriesInput, color, context, octokit);
+    expect(octokit.rest.issues.addLabels).toHaveBeenCalledWith({
+      ...context.repo,
+      issue_number: prNumber,
+      labels: ['PR Size: L']
     });
   });
 
   it('handles errors', async function() {
+    let directoriesInput;
+
     spyOn(octokit.rest.pulls, 'get').and.callFake(function() {
       return Promise.reject(new Error('woops'));
     });
 
     try {
-      await sizePR(false, [], color, context, octokit);
+      await sizePR(false, directoriesInput, color, context, octokit);
     } catch (error) {
       expect(error).toEqual(new Error('woops'));
     }

--- a/src/size-pr.js
+++ b/src/size-pr.js
@@ -3,11 +3,16 @@ const totalLines = require('./total-lines.js');
 const ensureLabelExists = require('./ensure-label-exists.js');
 const labelPR = require('./label-pr.js');
 
-async function sizePR(excludeSpecs, excludedDirectories, color, context, octokit) {
+async function sizePR(specsInput, directoriesInput, color, context, octokit) {
   try {
     const repo = context.repo;
     const prNumber = context.payload.pull_request.number;
     const prLabels = context.payload.pull_request.labels;
+    const excludeSpecs = (specsInput === 'true' || specsInput === 1) || false;
+    const excludedDirectories =
+      directoriesInput === null || directoriesInput === undefined
+        ? []
+        : directoriesInput.split(',');
 
     const total = await totalLines(excludeSpecs, excludedDirectories, repo, prNumber, octokit);
     const { label, description } = size(total);


### PR DESCRIPTION
This PR:
* fixes how the `excluded_directories` input from the workflow file configuration is handled
* refactors a bit